### PR TITLE
fix Trapezoid LEFT bug

### DIFF
--- a/lib/src/trapezoid_clipper.dart
+++ b/lib/src/trapezoid_clipper.dart
@@ -56,7 +56,7 @@ class TrapezoidClipper extends CustomClipper<Path> {
     path.moveTo(0.0, cutLength);
     path.lineTo(0.0, size.height - cutLength);
     path.lineTo(size.width, size.height);
-    path.lineTo(size.height, 0.0);
+    path.lineTo(size.width, 0.0);
     path.close();
     return path;
   }


### PR DESCRIPTION
When I used Trapezoid in this package with Edge.LEFT, it didn't work well.
![image](https://user-images.githubusercontent.com/31440714/76520075-8ca18b00-64a5-11ea-9299-0c8249bf5de8.png)
I found a bug, so I make this PR.
Thank you.